### PR TITLE
change symblos for render landscape

### DIFF
--- a/Map.cs
+++ b/Map.cs
@@ -19,11 +19,11 @@ namespace Game
                 {
                     // generate and fill lines
                     if (i + 1 == pixelesMap.Length)
-                    { line[j] = "_"; }
+                    { line[j] = "▔"; }
                     else if (j != 0 && j + 1 != line.Length)
                     { line[j] = " "; }
                     if (j == 0 || j + 1 == line.Length)
-                    { line[j] = "|"; }
+                    { line[j] = "┃"; }
                 }
                 pixelesMap[i] = line;
             }

--- a/Prerender.cs
+++ b/Prerender.cs
@@ -5,6 +5,7 @@ namespace Game
         static public void Prerender(List<IRenderable> renderableEntities, string[][] prerenderableView)
         {
             foreach (IRenderable entity in renderableEntities)
+            {
                 for (var i = 0; i < entity.shape.Length; i++)
                 {
 
@@ -17,7 +18,7 @@ namespace Game
                         }
                     }
                 }
-
+            }
         }
     }
 }


### PR DESCRIPTION
changed symbols for landscape form "|", "_" -> "┃", "▔"